### PR TITLE
Docker Integration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && \
+    apt-get install -y locales && \
+    rm -rf /var/lib/apt/lists/* && \
+    echo "cs_CZ.UTF-8 UTF-8" > /etc/locale.gen && \
+    locale-gen && \
+    update-locale LANG=cs_CZ.UTF-8 && \
+    dpkg-reconfigure locales
+
+ENV LANG=cs_CZ.UTF-8 \
+    LC_ALL=cs_CZ.UTF-8 \
+    LC_CTYPE=cs_CZ.UTF-8 \
+    PIP_DEFAULT_TIMEOUT=100 \
+    PYTHONUNBUFFERED=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    PIP_NO_CACHE_DIR=1
+
+COPY requirements.txt /app/requirements.txt
+RUN pip install -r requirements.txt
+
+
+COPY . /app

--- a/README.md
+++ b/README.md
@@ -7,6 +7,15 @@ Otevřete terminál a naklonujte tento repozitář:
 git clone https://github.com/terezakazmir/Tiskarny-barokni-Prahy.git
 cd Tiskarny-barokni-Prahy
 ```
+Další kroky závisí na tom, zda chcete aplikaci spustit v Dockeru nebo bez něj.
+
+### Docker
+Nainstalujte [Docker Desktop](https://docs.docker.com/desktop/) a spusťte aplikaci pomocí příkazu:
+```bash
+docker compose up
+```
+
+### Lokálni instalace
 Vytvořte a aktivujte virtuální prostředí:
 
 **`Windows (Příkazový řádek):`**
@@ -33,4 +42,16 @@ Spusťte aplikaci:
 ```bash
 python app.py
 ```
-Otevřete zobrazené URL. Standardně bude aplikace běžet na [http://127.0.0.1:8050/](http://127.0.0.1:8050/).
+
+### Zobrazení aplikace
+
+V obou případech se v terminálu zobrazí URL, na které bude aplikace dostupná. Standardně bude aplikace běžet na [http://127.0.0.1:8050/](http://127.0.0.1:8050/).
+
+
+Aplikace dovoluje změnit pouzitý port a hostname pomocí argumentů `--port` a `--host`:
+
+```bash
+python app.py --port 8050 --host 0.0.0.0
+```
+
+Pro změnu portu a hostname při spuštení pomocí `docker compose` upravte sekci `command` v souboru `docker-compose.yaml`.

--- a/app.py
+++ b/app.py
@@ -1,6 +1,7 @@
 import dash
 from dash import html, dcc
 import dash_bootstrap_components as dbc
+import argparse
 
 app = dash.Dash(__name__, external_stylesheets=[dbc.themes.BOOTSTRAP], use_pages=True)
 
@@ -38,5 +39,17 @@ def redirect_to_default(pathname):
     return dash.no_update
 
 
+parser = argparse.ArgumentParser(
+    description="Run the Dash app",
+    formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+)
+parser.add_argument("--port", type=int, default=8050, help="Port to run the app on")
+parser.add_argument(
+    "--host", type=str, default="0.0.0.0", help="Host to run the app on"
+)
+parser.add_argument("--debug", action="store_true", help="Run the app in debug mode")
+
+args = parser.parse_args()
+
 if __name__ == "__main__":
-    app.run_server(debug=False)
+    app.run(host=args.host, port=str(args.port), debug=args.debug)

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,15 @@
+services:
+  app:
+    command:
+      - "python"
+      - "app.py"
+      - "--port"
+      - "8050"
+      - "--host"
+      - "0.0.0.0"
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "8050:8050"
+


### PR DESCRIPTION
# Docker Integration

- added `Dockerfile` and `docker-compose.yaml`
- updated `README.md` with instructions on how to use the app with `docker`
- updated `app.py` to accept `--port`, `--host`, and `--debug` arguments for easier configuration if needed

The app can now be started using `docker compose up` and will run on the same address as the local version.
If you make changes to the code, run the app using `docker compose up --build` instead which will build a new image instead of reusing the previous one.

Once there will be no more changes necessary, you can push the latest built image to `dockerhub` and update the `docker-compose.yaml` by replacing the entire `build:` section with `image: <name of the pushed image>`